### PR TITLE
Load the model editors, and all of their images, at once

### DIFF
--- a/hoothub/lib/screens/make_test/editors.dart
+++ b/hoothub/lib/screens/make_test/editors.dart
@@ -36,7 +36,7 @@ class QuestionModelEditor {
   });
 
   TextEditingController questionEditingController;
-  Future<Uint8List?> image;
+  Uint8List? image;
   List<TextEditingController> answerEditingControllers;
   int correctAnswer;
   int secondsDuration;
@@ -44,12 +44,13 @@ class QuestionModelEditor {
   /// Converts `question` into its `QuestionModelEditor` equivalent.
   ///
   /// WARNING: IF `testId` IS NOT NULL,
-  /// THIS METHOD ASSIGNS `image` TO A `Future<Uint8List?>` THAT DOWNLOADS
-  /// THIS QUESTION'S IMAGE FROM CLOUD STORAGE, USING `downloadQuestionImage`.
-  static QuestionModelEditor fromQuestion(String? testId, int questionIndex, Question question) {
+  /// THIS METHOD DOWNLOADS
+  /// THIS QUESTION'S IMAGE FROM CLOUD STORAGE, USING `downloadQuestionImage`,
+  /// AND ASSIGNS IT TO `image`.
+  static Future<QuestionModelEditor> fromQuestion(String? testId, int questionIndex, Question question) async {
     return QuestionModelEditor(
       questionEditingController: TextEditingController(text: question.question),
-      image: testId != null ? downloadQuestionImage(testId, questionIndex) : Future<Uint8List?>.value(null),
+      image: testId != null ? (await downloadQuestionImage(testId, questionIndex)) : null,
       answerEditingControllers: List<TextEditingController>.from(
         question.answers.map<TextEditingController>(
           (String answer) => TextEditingController(text: answer),
@@ -129,7 +130,7 @@ class TestModelEditor {
   String? id;
   String? userId;
   TextEditingController nameEditingController;
-  Future<Uint8List?> image;
+  Uint8List? image;
   Timestamp? dateCreated;
   List<QuestionModelEditor> questionModelEditors;
   Map<String, TestResult> userResults = <String, TestResult>{};
@@ -140,20 +141,21 @@ class TestModelEditor {
   /// Converts `test` to its `TestModelEditor` equivalent.
   ///
   /// WARNING: IF `testId` IS NOT NULL,
-  /// THIS METHOD ASSIGNS `image` TO A `Future<Uint8List?>` THAT DOWNLOADS
-  /// THIS TESTS'S IMAGE FROM CLOUD STORAGE, USING `downloadTestImage`.
+  /// THIS METHOD DOWNLOADS
+  /// THIS TESTS'S IMAGE FROM CLOUD STORAGE, USING `downloadTestImage`,
+  /// AND ASSIGNS IT TO `image`.
   ///
   /// THIS METHOD ALSO CONVERTS EACH QUESTION IN `test.questions` TO A
   /// `QuestionModelEditor`, USING `QuestionModelEditor.fromQuestion(<current question>)`,
-  /// WHICH ALSO DOWNLOADS THE QUESTION'S IMAGE IN A FUTURE, USING `downloadQuestionImage`,
+  /// WHICH ALSO DOWNLOADS THE QUESTION'S IMAGE, USING `downloadQuestionImage`,
   /// AND ASSIGNS IT TO THE QUESTION'S `image` FIELD.
-  static TestModelEditor fromTest(Test test) {
+  static Future<TestModelEditor> fromTest(Test test) async {
     String? testId = test.id;
 
     List<QuestionModelEditor> questionModelEditors = <QuestionModelEditor>[];
 
     for (final (int index, Question question) in test.questions.indexed) {
-      final QuestionModelEditor questionModelEditor = QuestionModelEditor.fromQuestion(
+      final QuestionModelEditor questionModelEditor = await QuestionModelEditor.fromQuestion(
         testId, index, question,
       );
 
@@ -164,7 +166,7 @@ class TestModelEditor {
       id: testId,
       userId: test.userId,
       nameEditingController: TextEditingController(text: test.name),
-      image: testId != null ? downloadTestImage(testId) : Future<Uint8List?>.value(null),
+      image: testId != null ? (await downloadTestImage(testId)) : null,
       dateCreated: test.dateCreated,
       questionModelEditors: questionModelEditors,
       userResults: test.userResults,
@@ -214,7 +216,7 @@ class TestModelEditor {
     questionModelEditors.add(
       QuestionModelEditor(
         questionEditingController: TextEditingController(),
-        image: Future<Uint8List?>.value(null),
+        image: null,
         answerEditingControllers: <TextEditingController>[TextEditingController(), TextEditingController()],
         correctAnswer: 0,
       ),

--- a/hoothub/lib/screens/make_test/make_test.dart
+++ b/hoothub/lib/screens/make_test/make_test.dart
@@ -51,7 +51,7 @@ class _MakeTestState extends State<MakeTest> {
   // default index. May not be in the bounds of `testModel!.questions`,
   // since that could be empty!
   late int _currentSlideIndex;
-  late TestModelEditor _testModel;
+  late Future<TestModelEditor> _testModel;
 
   @override
   void initState() {
@@ -66,8 +66,8 @@ class _MakeTestState extends State<MakeTest> {
   /// with the error.
   ///
   /// TODO: UPLOAD THE IMAGES TO THEIR CORRECT SLOTS IN CLOUD STORAGE AS WELL!
-  Future<void> _onTestSaved(BuildContext context) async {
-    Test testModel = _testModel.toTest();
+  Future<void> _onTestSaved(BuildContext context, TestModelEditor testModelEditor) async {
+    Test testModel = testModelEditor.toTest();
 
     if (!(testModel.isValid()) && context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -93,13 +93,13 @@ class _MakeTestState extends State<MakeTest> {
 
       // SAVE TEST'S IMAGES
 
-      // Need `_testModel` for the test's image
-      Uint8List? testImage = await _testModel.image;
+      // Need `testModelEditor` for the test's image
+      Uint8List? testImage = await testModelEditor.image;
 
       if (testImage != null) {
         // Can't promote non-final fields
         try {
-          // Need `testModel`, NOT `_testModel` FOR THE TEST'S ID.
+          // Need `testModel`, NOT `testModelEditor` FOR THE TEST'S ID.
           //
           // `testModel` SHOULD NOW HAVE AN `id` FIELD.
           // IF IT DOESN'T, THE ERROR MESSAGE WILL CATCH THE ERROR:
@@ -112,14 +112,14 @@ class _MakeTestState extends State<MakeTest> {
         }
       }
 
-      // Need `_testModel.questionModelEditors` for the questions' images
-      for (final (int index, QuestionModelEditor questionModelEditor) in _testModel.questionModelEditors.indexed) {
+      // Need `testModelEditor.questionModelEditors` for the questions' images
+      for (final (int index, QuestionModelEditor questionModelEditor) in testModelEditor.questionModelEditors.indexed) {
         final Uint8List? questionImage = await questionModelEditor.image;
 
         if (questionImage == null) continue;
 
         try {
-          // Need `testModel`, NOT `_testModel` FOR THE TEST'S ID.
+          // Need `testModel`, NOT `testModelEditor` FOR THE TEST'S ID.
           //
           // `testModel` SHOULD NOW HAVE AN `id` FIELD.
           // IF IT DOESN'T, THE ERROR MESSAGE WILL CATCH THE ERROR:
@@ -142,11 +142,11 @@ class _MakeTestState extends State<MakeTest> {
 
       // `testModel` SHOULD NOW HAVE ITS `id` AND OTHER FIELDS,
       // BECAUSE IT WAS UPLOADED BY `saveTest`.
-      // NOW, WE HAVE TO UPDATE `_testModel` WITH IT:
+      // NOW, WE HAVE TO UPDATE `testModelEditor` WITH IT:
       //
       // IF WE DON'T, AND THE PLAYER SAVES THIS TEST AGAIN,
       // AND THIS TEST IS A NEW TEST,
-      // SINCE THE `_testModel` DOESN'T YET HAVE AN `id`,
+      // SINCE THE `testModelEditor` DOESN'T YET HAVE AN `id`,
       // IT WILL BE SAVED TWICE TO CLOUD FIRESTORE.
 
       if (!mounted) return;
@@ -159,17 +159,32 @@ class _MakeTestState extends State<MakeTest> {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> sidePanelWithSlidePreviews = <Widget>[
-      InfoDownloader(
-        downloadInfo: () => _testModel.image,
-        builder: (BuildContext context, Uint8List? result, bool downloaded) {
-          return ImageEditor(
-            imageData: result,
+    return InfoDownloader<TestModelEditor>(
+      downloadInfo: () => _testModel,
+      builder: (BuildContext context, TestModelEditor? testModel, bool downloaded) {
+        if (testModel == null) {
+          return Scaffold(
+            appBar: AppBar(
+              title: const Text('HootHub'),
+              actions: <Widget>[
+                ElevatedButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Exit'),
+                ),
+              ],
+            ),
+            body: const Center(child: Text("Oops! The test's model editor didn't load!")),
+          );
+        }
+
+        final List<Widget> sidePanelWithSlidePreviews = <Widget>[
+          ImageEditor(
+            imageData: testModel.image,
             asyncOnChange: (Uint8List newImage) {
               if (!mounted) return;
 
               setState(() {
-                _testModel.image = Future<Uint8List?>.value(newImage);
+                testModel.image = newImage;
               });
             },
             asyncOnImageNotRecieved: () {
@@ -179,76 +194,67 @@ class _MakeTestState extends State<MakeTest> {
                 const SnackBar(content: Text('Image not recieved!')),
               );
             },
-          );
-        },
-        buildError: (BuildContext context, Object error) {
-          return Text("Error building test ${_testModel.id}'s image: $error");
-        },
-      ),
-    ];
-
-    for (final (int index, QuestionModelEditor question) in _testModel.questionModelEditors.indexed) {
-      sidePanelWithSlidePreviews.add(
-        InkWell(
-          onTap: () => setState(() {
-            // `index` should be within the index bounds of `testModel.questions`,
-            // so `_currentSlideIndex` should also be, after this `setState` call.
-            // So, this assignment is valid.
-            _currentSlideIndex = index;
-          }),
-          child: SlidePreview(
-            questionIndex: index,
-            // TODO: HOW TO REFRESH DISPLAYED QUESTION WHEN THE USER EDITS IT?
-            question: question.questionEditingController.text, 
-            questionImage: question.image,
-            deleteQuestion: () => setState(() {
-              _testModel.deleteQuestion(_currentSlideIndex);
-            }),
           ),
-        ),
-      );
-    }
+        ];
 
-    /*
-      Add an `AddSlideButton` at the bottom of the `slidePreviews` `List<Widget>`.
-      When pressed, it should add a new (EMPTY) question to `testModel.questions`,
-      add a new null image to `_questionImages`,
-      and automatically change `_currentSlideIndex` to the index of this new `Question`.
+        for (final (int index, QuestionModelEditor question) in testModel.questionModelEditors.indexed) {
+          sidePanelWithSlidePreviews.add(
+            InkWell(
+              onTap: () => setState(() {
+                // `index` should be within the index bounds of `testModel.questions`,
+                // so `_currentSlideIndex` should also be, after this `setState` call.
+                // So, this assignment is valid.
+                _currentSlideIndex = index;
+              }),
+              child: SlidePreview(
+                questionIndex: index,
+                // TODO: HOW TO REFRESH DISPLAYED QUESTION WHEN THE USER EDITS IT?
+                question: question.questionEditingController.text, 
+                questionImage: question.image,
+                deleteQuestion: () => setState(() {
+                  testModel.deleteQuestion(_currentSlideIndex);
+                }),
+              ),
+            ),
+          );
+        }
 
-      This means that pressing this `AddSlideButton` will automatically jump to the last
-      slide, where the user SHOULD be able to edit the last question.
-    */
-    sidePanelWithSlidePreviews.add(
-      AddSlideButton(
-        onPressed: () {
-          setState(() {
-            _testModel.addNewEmptyQuestion();
-            _currentSlideIndex = _testModel.questionModelEditors.length - 1;
-          });
-        },
-      ),
-    );
+        /*
+          Add an `AddSlideButton` at the bottom of the `slidePreviews` `List<Widget>`.
+          When pressed, it should add a new (EMPTY) question to `testModel.questions`,
+          add a new null image to `_questionImages`,
+          and automatically change `_currentSlideIndex` to the index of this new `Question`.
 
-    final Widget currentSlideEditor = (
-      // `_currentSlideIndex` may be out of the range of the list.
-      // In the case that it is,
-      // the `AddSlideButton` "slide" will be displayed instead.
-      _currentSlideIndex < 0 || _currentSlideIndex >= _testModel.questionModelEditors.length
-      ? const Center(child: Text('No questions yet!'))
-      : Expanded(
-        child: SlideEditor(
-          questionModelEditor: _testModel.questionModelEditors[_currentSlideIndex],
-          questionImageEditor: InfoDownloader<Uint8List>(
-            key: UniqueKey(), // TO RE-BUILD THE CURRENT QUESTION'S IMAGE EDITOR WHEN THE CURRENT SLIDE EDITOR CHANGES
-            downloadInfo: () => _testModel.questionModelEditors[_currentSlideIndex].image,
-            builder: (BuildContext context, Uint8List? result, bool downloaded) {
-              return ImageEditor(
-                imageData: result,
+          This means that pressing this `AddSlideButton` will automatically jump to the last
+          slide, where the user SHOULD be able to edit the last question.
+        */
+        sidePanelWithSlidePreviews.add(
+          AddSlideButton(
+            onPressed: () {
+              setState(() {
+                testModel.addNewEmptyQuestion();
+                _currentSlideIndex = testModel.questionModelEditors.length - 1;
+              });
+            },
+          ),
+        );
+
+        final Widget currentSlideEditor = (
+          // `_currentSlideIndex` may be out of the range of the list.
+          // In the case that it is,
+          // the `AddSlideButton` "slide" will be displayed instead.
+          _currentSlideIndex < 0 || _currentSlideIndex >= testModel.questionModelEditors.length
+          ? const Center(child: Text('No questions yet!'))
+          : Expanded(
+            child: SlideEditor(
+              questionModelEditor: testModel.questionModelEditors[_currentSlideIndex],
+              questionImageEditor: ImageEditor(
+                imageData: testModel.questionModelEditors[_currentSlideIndex].image,
                 asyncOnChange: (Uint8List newImage) {
                   if (!mounted) return;
 
                   setState(() {
-                    _testModel.questionModelEditors[_currentSlideIndex].image = Future<Uint8List?>.value(newImage);
+                    testModel.questionModelEditors[_currentSlideIndex].image = newImage;
                   });
                 },
                 asyncOnImageNotRecieved: () {
@@ -261,64 +267,75 @@ class _MakeTestState extends State<MakeTest> {
                     const SnackBar(content: Text("Question's image not recieved!")),
                   );
                 },
-              );
-            },
-            buildError: (BuildContext context, Object error) {
-              return Text("Error loading and displaying question #$_currentSlideIndex's image editor: $error");
-            },
-          ),
-          deleteQuestion: () => setState(() {
-            _testModel.deleteQuestion(_currentSlideIndex);
-          }),
-          addNewEmptyAnswer: () => setState(() {
-            _testModel.addNewEmptyAnswer(_currentSlideIndex);
-          }),
-          deleteAnswer: (int answerIndex) => setState(() {
-            _testModel.deleteAnswer(_currentSlideIndex, answerIndex);
-          }),
-          setCorrectAnswer: (int answerIndex) => setState(() {
-            _testModel.setCorrectAnswer(_currentSlideIndex, answerIndex);
-          }),
-          setSecondsDuration: (int secondsDuration) => setState(() {
-            _testModel.setSecondsDuration(_currentSlideIndex, secondsDuration);
-          }),
-        ),
-      )
-    );
+              ),
+              deleteQuestion: () => setState(() {
+                testModel.deleteQuestion(_currentSlideIndex);
+              }),
+              addNewEmptyAnswer: () => setState(() {
+                testModel.addNewEmptyAnswer(_currentSlideIndex);
+              }),
+              deleteAnswer: (int answerIndex) => setState(() {
+                testModel.deleteAnswer(_currentSlideIndex, answerIndex);
+              }),
+              setCorrectAnswer: (int answerIndex) => setState(() {
+                testModel.setCorrectAnswer(_currentSlideIndex, answerIndex);
+              }),
+              setSecondsDuration: (int secondsDuration) => setState(() {
+                testModel.setSecondsDuration(_currentSlideIndex, secondsDuration);
+              }),
+            ),
+          )
+        );
 
-    return Scaffold(
-      appBar: AppBar(
-        title: TextField(
-          controller: _testModel.nameEditingController,
-          cursorColor: white,
-          decoration: const InputDecoration(
-            hintText: 'Title',
-          ),
-        ),
-        actions: <Widget>[
-          ElevatedButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Exit'),
-          ),
-          Builder(
-            builder: (BuildContext context) =>  ElevatedButton(
-              onPressed: () => _onTestSaved(context),
-              child: const Text('Save'),
+        return Scaffold(
+          appBar: AppBar(
+            title: TextField(
+              controller: testModel.nameEditingController,
+              cursorColor: white,
+              decoration: const InputDecoration(
+                hintText: 'Title',
+              ),
             ),
+            actions: <Widget>[
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Exit'),
+              ),
+              Builder(
+                builder: (BuildContext context) =>  ElevatedButton(
+                  onPressed: () => _onTestSaved(context, testModel),
+                  child: const Text('Save'),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
-      body: Row(
-        children: <Widget>[
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 400),
-            child: ListView(
-              children: sidePanelWithSlidePreviews,
-            ),
+          body: Row(
+            children: <Widget>[
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 400),
+                child: ListView(
+                  children: sidePanelWithSlidePreviews,
+                ),
+              ),
+              currentSlideEditor,
+            ],
           ),
-          currentSlideEditor,
-        ],
-      ),
+        );
+      },
+      buildError: (BuildContext context, Object error) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('HootHub'),
+            actions: <Widget>[
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Exit'),
+              ),
+            ],
+          ),
+          body: const Center(child: Text("Oops! There was an error loading the test's model editor!")),
+        );
+      },
     );
   }
 }

--- a/hoothub/lib/screens/make_test/slide_preview.dart
+++ b/hoothub/lib/screens/make_test/slide_preview.dart
@@ -2,7 +2,6 @@
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:hoothub/screens/styles.dart';
-import 'package:hoothub/screens/widgets/info_downloader.dart';
 
 class SlidePreview extends StatelessWidget {
   const SlidePreview({
@@ -15,11 +14,13 @@ class SlidePreview extends StatelessWidget {
 
   final int questionIndex;
   final String question;
-  final Future<Uint8List?> questionImage;
+  final Uint8List? questionImage;
   final void Function() deleteQuestion;
 
   @override
   Widget build(BuildContext context) {
+    Uint8List? questionImageData = questionImage;
+
     final List<Widget> children = <Widget>[
       Container(
         alignment: Alignment.centerLeft,
@@ -42,21 +43,10 @@ class SlidePreview extends StatelessWidget {
         ),
       ),
       Text(question, style: const TextStyle(fontSize: 50)),
-      InfoDownloader<Uint8List>(
-        key: UniqueKey(),
-        downloadInfo: () => questionImage,
-        builder: (BuildContext context, Uint8List? result, bool downloaded) {
-          Image questionImageWidget = Image.asset('default_image.png');
-
-          if (result != null) {
-            questionImageWidget = Image.memory(result);
-          }
-
-          return questionImageWidget;
-        },
-        buildError: (BuildContext context, Object error) {
-          return Text("Error loading and displaying question #$questionIndex's image: $error");
-        },
+      (
+        questionImageData != null 
+        ? Image.memory(questionImageData)
+        : Image.asset('default_image.png')
       ),
     ];
 


### PR DESCRIPTION
Before, we were downloading all of the images through individual `Future<Uint8List?>`s, in each `...ModelEditor`. The `TestModelEditor.fromTest` and `QuestionModelEditor.fromQuestion` methods would return their corresponding instance, with a `Future<Uint8List?> image` attribute, that would download the corresponding image from Cloud Firestore. All images were displayed with `InfoDownloader`s, that would all, IN PARALLEL, wait for each image to download, before displaying them.

My hypothesis, is that this made it very difficult to scroll through the side panel with `SlidePreview`s, because whenever a `SlidePreview` went off-screen and came back, it would re-load its image. While scrolling, the images loading offset the scroll position of the panel. But, that offset would sometimes UNLOAD OTHER IMAGES PUSHED OFF-SCREEN. This would stagger the scrolling of the left side panel.

By awaiting for the `_testModel` state to load ALL AT ONCE, we don't have to wrap any of the `MakeTest`'s images inside an `InfoDownloader`, since the image fields won't be `Future`s anymore, and they will be displayed faster.

We instead wrap all of the content of `MakeTest` inside an `InfoDownloader`, which awaits for the `_testModel` to finish loading.