### PR TITLE
Make all models immutable

### DIFF
--- a/hoothub/lib/firebase/models/comment_tree.dart
+++ b/hoothub/lib/firebase/models/comment_tree.dart
@@ -14,14 +14,14 @@ class CommentTree implements Model {
     required this.replyIds,
   });
 
-  String? id;
-  String? userId;
-  String? testId;
-  String? parentCommentId;
-  String comment;
-  List<String> usersThatUpvoted;
-  List<String> usersThatDownvoted;
-  List<String> replyIds;
+  final String? id;
+  final String? userId;
+  final String? testId;
+  final String? parentCommentId;
+  final String comment;
+  final List<String> usersThatUpvoted;
+  final List<String> usersThatDownvoted;
+  final List<String> replyIds;
 
   /// A `CommentTree` is a valid Firestore document
   /// if it has a non-empty comment.
@@ -38,6 +38,20 @@ class CommentTree implements Model {
   bool isValid() {
     return comment.isNotEmpty;
   }
+
+  /// Returns a DEEP copy of `this`.
+  ///
+  /// Immutable fields are not copied.
+  CommentTree copy() => CommentTree(
+    id: id,
+    userId: userId,
+    testId: testId,
+    parentCommentId: parentCommentId,
+    comment: comment,
+    usersThatUpvoted: List.of(usersThatUpvoted),
+    usersThatDownvoted: List.of(usersThatDownvoted),
+    replyIds: List.of(replyIds),
+  );
 
   static CommentTree? fromSnapshot(DocumentSnapshot<Map<String, dynamic>> snapshot) {
     final Map<String, dynamic>? data = snapshot.data();

--- a/hoothub/lib/firebase/models/iterable_equals.dart
+++ b/hoothub/lib/firebase/models/iterable_equals.dart
@@ -1,0 +1,14 @@
+bool iterableEquals<T>(Iterable<T> a, Iterable<T> b, bool Function(T, T) equals) {
+  if (a.length != b.length) return false;
+
+  final Iterator<T> aIterator = a.iterator;
+  final Iterator<T> bIterator = b.iterator;
+
+  while (aIterator.moveNext() && bIterator.moveNext()) {
+    if (!equals(aIterator.current, bIterator.current)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/hoothub/lib/firebase/models/model.dart
+++ b/hoothub/lib/firebase/models/model.dart
@@ -3,4 +3,5 @@ abstract class Model {
   /// PLEASE CALL BEFORE UPLOADING THE MODEL TO FIREBASE.
   bool isValid();
   Map<String, dynamic> toJson();
+  // Model copy();
 }

--- a/hoothub/lib/firebase/models/question.dart
+++ b/hoothub/lib/firebase/models/question.dart
@@ -1,3 +1,4 @@
+import 'iterable_equals.dart';
 import 'model.dart';
 
 /// Dependent `Model` for `Test` to use.
@@ -26,6 +27,13 @@ class Question implements Model {
     && answers.length > 1
     && 0 <= correctAnswer && correctAnswer < answers.length
     && 1 <= secondsDuration && secondsDuration <= 60
+  );
+
+  bool equals(Question other) => (
+    question == other.question
+    && iterableEquals(answers, other.answers, (String a, String b) => a == b)
+    && correctAnswer == other.correctAnswer
+    && secondsDuration == other.secondsDuration
   );
 
   /// Returns a DEEP copy of `this`.

--- a/hoothub/lib/firebase/models/question.dart
+++ b/hoothub/lib/firebase/models/question.dart
@@ -10,10 +10,10 @@ class Question implements Model {
     this.secondsDuration = 20,
   });
 
-  String question;
-  List<String> answers;
-  int correctAnswer;
-  int secondsDuration;
+  final String question;
+  final List<String> answers;
+  final int correctAnswer;
+  final int secondsDuration;
 
   /// A `Question` is valid if:
   /// - Its `question` is not empty
@@ -28,43 +28,14 @@ class Question implements Model {
     && 1 <= secondsDuration && secondsDuration <= 60
   );
 
-  /// Sets `this.question: question`.
-  void setQuestion(String question) {
-    this.question = question;
-  }
-
-  /// Throws error if `index` is out of the range of `answers`.
-  void _checkAnswerIndex(int index) {
-    if (index < 0 || index >= answers.length) {
-      throw "Answer index out of range: $index";
-    }
-  }
-
-  /// Sets `answers`'s `index`-th answer equal to `answer`.
+  /// Returns a DEEP copy of `this`.
   ///
-  /// Throws an error if the index is outside the range of `answers`.
-  void setAnswer(int index, String answer) {
-    _checkAnswerIndex(index);
-    answers[index] = answer;
-  }
-
-  /// Sets `correctAnswer: index`.
-  ///
-  /// Throws an error if the index is outside the range of `answers`.
-  void setCorrectAnswer(int index) {
-    _checkAnswerIndex(index);
-    correctAnswer = index;
-  }
-
-  /// Adds a new, empty answer to the end of `answers`.
-  void addNewEmptyAnswer() {
-    answers.add('');
-  }
-
-  /// Sets `this.secondsDuration: secondsDuration`.
-  void setSecondsDuration(int secondsDuration) {
-    this.secondsDuration = secondsDuration;
-  }
+  /// Immutable fields are not copied.
+  Question copy() => Question(
+    question: question,
+    answers: List<String>.of(answers),
+    correctAnswer: correctAnswer,
+  );
 
   static Question fromJson(Map<String, dynamic> data) {
     return Question(

--- a/hoothub/lib/firebase/models/test.dart
+++ b/hoothub/lib/firebase/models/test.dart
@@ -1,3 +1,4 @@
+import 'iterable_equals.dart';
 import 'model.dart';
 import 'question.dart';
 import 'test_result.dart';
@@ -115,6 +116,24 @@ class Test implements Model {
     return usersThatDownvoted.contains(userId);
   }
 
+  bool equals(Test other) {
+    return (
+      id == other.id
+      && userId == other.userId
+      && name == other.name
+      && dateCreated == other.dateCreated
+      && iterableEquals(questions, other.questions, (Question a, Question b) => a.equals(b))
+      && iterableEquals(
+        userResults.entries,
+        other.userResults.entries,
+        (MapEntry<String, TestResult> a, MapEntry<String, TestResult> b) => a.key == b.key && a.value.equals(b.value)
+      )
+      && iterableEquals(usersThatUpvoted, other.usersThatUpvoted, (String a, String b) => a == b)
+      && iterableEquals(usersThatDownvoted, other.usersThatDownvoted, (String a, String b) => a == b)
+      && iterableEquals(comments, other.comments, (String a, String b) => a == b)
+    );
+  }
+
   Test setId(String? newId) => Test(
     id: newId,
     userId: userId,
@@ -124,6 +143,7 @@ class Test implements Model {
     userResults: Map<String, TestResult>.of(userResults),
     usersThatUpvoted: List<String>.of(usersThatUpvoted),
     usersThatDownvoted: List<String>.of(usersThatDownvoted),
+    comments: List<String>.of(comments),
   );
 
   Test setUserId(String? newUserId) => Test(
@@ -135,6 +155,7 @@ class Test implements Model {
     userResults: Map<String, TestResult>.of(userResults),
     usersThatUpvoted: List<String>.of(usersThatUpvoted),
     usersThatDownvoted: List<String>.of(usersThatDownvoted),
+    comments: List<String>.of(comments),
   );
 
   Test setDateCreated(Timestamp? newDateCreated) => Test(
@@ -146,6 +167,7 @@ class Test implements Model {
     userResults: Map<String, TestResult>.of(userResults),
     usersThatUpvoted: List<String>.of(usersThatUpvoted),
     usersThatDownvoted: List<String>.of(usersThatDownvoted),
+    comments: List<String>.of(comments),
   );
 
   /// Returns DEEP COPY of `this`.
@@ -160,6 +182,7 @@ class Test implements Model {
     userResults: Map<String, TestResult>.of(userResults),
     usersThatUpvoted: List<String>.of(usersThatUpvoted),
     usersThatDownvoted: List<String>.of(usersThatDownvoted),
+    comments: List<String>.of(comments),
   );
 
   /// Returns the `Test` representation of `snapshot.data()`.

--- a/hoothub/lib/firebase/models/test.dart
+++ b/hoothub/lib/firebase/models/test.dart
@@ -38,33 +38,50 @@ class Test implements Model {
   }) {
     if (name != null) {
       this.name = name;
+    } else {
+      this.name = '';
     }
+
     if (questions != null) {
       this.questions = questions;
+    } else {
+      this.questions = <Question>[];
     }
+
     if (userResults != null) {
       this.userResults = userResults;
+    } else {
+      this.userResults = <String, TestResult>{};
     }
+
     if (usersThatUpvoted != null) {
       this.usersThatUpvoted = usersThatUpvoted;
+    } else {
+      this.usersThatUpvoted = <String>[];
     }
+
     if (usersThatDownvoted != null) {
       this.usersThatDownvoted = usersThatDownvoted;
+    } else {
+      this.usersThatDownvoted = <String>[];
     }
+
     if (comments != null) {
       this.comments = comments;
+    } else {
+      this.comments = <String>[];
     }
   }
 
-  String? id;
-  String? userId;
-  String name = '';
-  Timestamp? dateCreated;
-  List<Question> questions = <Question>[];
-  Map<String, TestResult> userResults = <String, TestResult>{};
-  List<String> usersThatUpvoted = <String>[];
-  List<String> usersThatDownvoted = <String>[];
-  List<String> comments = <String>[];
+  final String? id;
+  final String? userId;
+  late final String name;
+  final Timestamp? dateCreated;
+  late final List<Question> questions;
+  late final Map<String, TestResult> userResults;
+  late final List<String> usersThatUpvoted;
+  late final List<String> usersThatDownvoted;
+  late final List<String> comments;
 
   /// Validates `this` before it can be put in `FirebaseFirestore`.
   ///
@@ -98,76 +115,18 @@ class Test implements Model {
     return usersThatDownvoted.contains(userId);
   }
 
-  /// Sets `this.name: name`.
-  void setName(String name) {
-    this.name = name;
-  }
-
-  /// Adds a new, empty question at the end of `answers`
+  /// Returns DEEP COPY of `this`.
   ///
-  /// The new, empty question should have an empty title, answers,
-  /// should have answer 0 as the correct answer,
-  /// and should last its constructor's default time, of 20 seconds.
-  void addNewEmptyQuestion() {
-    questions.add(Question(question: '', answers: <String>['', ''], correctAnswer: 0));
-  }
-
-  /// Throws error if `index` is out of the range of `questions`.
-  void _checkQuestionIndex(int index) {
-    if (index < 0 || index >= questions.length) {
-      throw "Question index out of range: $index";
-    }
-  }
-
-  /// Sets `question: question` to the `questionIndex`-th question.
-  void setQuestion(int questionIndex, String question) {
-    _checkQuestionIndex(questionIndex);
-    questions[questionIndex].setQuestion(question);
-  }
-
-  /// Assigns `answer` to the `answerIndex`-th answer of the `questionIndex`-th question.
-  /// 
-  /// Throws if either the `questionIndex` is out of range of `questions`,
-  /// or if `answerIndex` is out of range of `questions[questionIndex].answers`. 
-  void setAnswer(int questionIndex, int answerIndex, String answer) {
-    _checkQuestionIndex(questionIndex);
-    questions[questionIndex].setAnswer(answerIndex, answer);
-  }
-
-  /// Assigns `correctAnswer: answerIndex` to the `questionIndex`-th question.
-  ///
-  /// Throws if either the `questionIndex` is out of range of `questions`,
-  /// or if `answerIndex` is out of range of `questions[questionIndex].answers`.
-  void setCorrectAnswer(int questionIndex, int answerIndex) {
-    _checkQuestionIndex(questionIndex);
-    questions[questionIndex].setCorrectAnswer(answerIndex);
-  }
-
-  /// Adds a new, empty answer to the end of the `answers` of the `questionIndex`-th question.
-  ///
-  /// Throws if the `questionIndex` is out of range of `questions`.
-  void addNewEmptyAnswer(int questionIndex) {
-    _checkQuestionIndex(questionIndex);
-    questions[questionIndex].addNewEmptyAnswer();
-  }
-
-  /// Sets the time duration, in seconds, of the `questionIndex`-th question.
-  ///
-  /// Throws if the `questionIndex` is out of range of `questions`.
-  void setSecondsDuration(int questionIndex, int secondsDuration) {
-    _checkQuestionIndex(questionIndex);
-    questions[questionIndex].setSecondsDuration(secondsDuration);
-  }
-
+  /// Immutable and deep fields are not copied.
   Test copy() => Test(
     id: id,
     userId: userId,
     name: name,
     dateCreated: dateCreated,
-    questions: questions,
-    userResults: userResults,
-    usersThatUpvoted: usersThatUpvoted,
-    usersThatDownvoted: usersThatDownvoted,
+    questions: List.of(questions),
+    userResults: Map<String, TestResult>.of(userResults),
+    usersThatUpvoted: List<String>.of(usersThatUpvoted),
+    usersThatDownvoted: List<String>.of(usersThatDownvoted),
   );
 
   /// Returns the `Test` representation of `snapshot.data()`.

--- a/hoothub/lib/firebase/models/test.dart
+++ b/hoothub/lib/firebase/models/test.dart
@@ -115,15 +115,48 @@ class Test implements Model {
     return usersThatDownvoted.contains(userId);
   }
 
+  Test setId(String? newId) => Test(
+    id: newId,
+    userId: userId,
+    name: name,
+    dateCreated: dateCreated,
+    questions: List.of(questions),
+    userResults: Map<String, TestResult>.of(userResults),
+    usersThatUpvoted: List<String>.of(usersThatUpvoted),
+    usersThatDownvoted: List<String>.of(usersThatDownvoted),
+  );
+
+  Test setUserId(String? newUserId) => Test(
+    id: id,
+    userId: newUserId,
+    name: name,
+    dateCreated: dateCreated,
+    questions: List.of(questions),
+    userResults: Map<String, TestResult>.of(userResults),
+    usersThatUpvoted: List<String>.of(usersThatUpvoted),
+    usersThatDownvoted: List<String>.of(usersThatDownvoted),
+  );
+
+  Test setDateCreated(Timestamp? newDateCreated) => Test(
+    id: id,
+    userId: userId,
+    name: name,
+    dateCreated: newDateCreated,
+    questions: List.of(questions),
+    userResults: Map<String, TestResult>.of(userResults),
+    usersThatUpvoted: List<String>.of(usersThatUpvoted),
+    usersThatDownvoted: List<String>.of(usersThatDownvoted),
+  );
+
   /// Returns DEEP COPY of `this`.
   ///
-  /// Immutable and deep fields are not copied.
+  /// Immutable fields are not copied.
   Test copy() => Test(
     id: id,
     userId: userId,
     name: name,
     dateCreated: dateCreated,
-    questions: List.of(questions),
+    questions: List<Question>.of(questions),
     userResults: Map<String, TestResult>.of(userResults),
     usersThatUpvoted: List<String>.of(usersThatUpvoted),
     usersThatDownvoted: List<String>.of(usersThatDownvoted),

--- a/hoothub/lib/firebase/models/test_result.dart
+++ b/hoothub/lib/firebase/models/test_result.dart
@@ -16,6 +16,12 @@ class TestResult implements Model {
   @override
   bool isValid() => true;
 
+  bool equals(TestResult other) => (
+    userId == other.userId
+    && correctAnswers == other.correctAnswers
+    && score == other.score
+  );
+
   static TestResult fromJson(Map<String, dynamic> data) {
     return TestResult(
       userId: data['userId'],

--- a/hoothub/lib/firebase/models/test_result.dart
+++ b/hoothub/lib/firebase/models/test_result.dart
@@ -24,7 +24,10 @@ class TestResult implements Model {
     );
   }
 
-  TestResult copy() => TestResult(correctAnswers: correctAnswers, score: score);
+  /// Returns a DEEP copy of `this`.
+  ///
+  /// Immutable fields are not copied.
+  TestResult copy() => TestResult(userId: userId, correctAnswers: correctAnswers, score: score);
 
   /// Returns a new `TestResult` instance, with the new score for the player,
   /// based on how they answered the current question.

--- a/hoothub/lib/firebase/models/user.dart
+++ b/hoothub/lib/firebase/models/user.dart
@@ -1,7 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'model.dart';
 
 /// Independent model representing a user.
-class UserModel {
+class UserModel implements Model {
   UserModel({
     required this.id,
     required this.username,
@@ -9,10 +10,24 @@ class UserModel {
     required this.tests,
   });
 
-  String id;
-  String username;
-  Timestamp dateCreated;
-  List<String> tests;
+  final String id;
+  final String username;
+  final Timestamp dateCreated;
+  final List<String> tests;
+
+  /// Always returns true, for now.
+  @override
+  bool isValid() => true;
+
+  /// Returns DEEP COPY of `this`.
+  ///
+  /// Immutable and deep fields are not copied.
+  UserModel copy() => UserModel(
+    id: id,
+    username: username,
+    dateCreated: dateCreated,
+    tests: List<String>.of(tests),
+  );
 
   /// Returns the `UserModel` representation of `snapshot.data()`.
   /// If the data is null, this method returns null.

--- a/hoothub/lib/firebase/models/user_scores.dart
+++ b/hoothub/lib/firebase/models/user_scores.dart
@@ -2,22 +2,31 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoothub/firebase/models/model.dart';
 
 /// Independent document `Model` that represents a corresponding `UserModel`'s test score statistics.
-class UserScores extends Model {
+class UserScores implements Model {
   UserScores({
     this.userId,
     required this.questionsAnswered,
     required this.questionsAnsweredCorrect,
   });
 
-  String? userId;
-  int questionsAnswered;
-  int questionsAnsweredCorrect;
+  final String? userId;
+  final int questionsAnswered;
+  final int questionsAnsweredCorrect;
 
   @override
   bool isValid() => questionsAnsweredCorrect >= 0
     && questionsAnswered >= 0
     && questionsAnsweredCorrect <= questionsAnswered
   ;
+
+  /// Returns DEEP COPY of `this`.
+  ///
+  /// Immutable and deep fields are not copied.
+  UserScores copy() => UserScores(
+    userId: userId,
+    questionsAnswered: questionsAnswered,
+    questionsAnsweredCorrect: questionsAnsweredCorrect,
+  );
 
   static UserScores? fromSnapshot(DocumentSnapshot<Map<String, dynamic>> snapshot) {
     Map<String, dynamic>? data = snapshot.data();

--- a/hoothub/lib/screens/play_test_solo/test_results.dart
+++ b/hoothub/lib/screens/play_test_solo/test_results.dart
@@ -6,10 +6,12 @@ class TestSoloResults extends StatelessWidget {
     super.key,
     required this.testResult,
     required this.questionsAmount,
+    required this.exit,
   });
 
   final TestResult testResult;
   final int questionsAmount;
+  final void Function() exit;
 
   @override
   Widget build(BuildContext context) {
@@ -40,9 +42,7 @@ class TestSoloResults extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
+              onPressed: exit,
               child: const Text('Back to Test Card'),
             ),
           ],

--- a/hoothub/lib/screens/view_tests/test_card.dart
+++ b/hoothub/lib/screens/view_tests/test_card.dart
@@ -8,8 +8,6 @@ import 'package:hoothub/firebase/api/images.dart';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:hoothub/screens/styles.dart';
-import 'package:hoothub/screens/play_test_solo/play_test_solo.dart';
-import 'package:hoothub/screens/make_test/make_test.dart';
 import 'package:hoothub/screens/widgets/info_downloader.dart';
 import 'questions_card.dart';
 
@@ -17,18 +15,26 @@ class TestCard extends StatelessWidget {
   const TestCard({
     super.key,
     required this.testModel,
+    required this.asyncSetTestModel,
+    required this.playSolo,
+    required this.edit,
     required this.color,
   });
 
   final Test testModel;
+  final void Function(Test newTestModel) asyncSetTestModel;
+  final void Function() playSolo;
+  final void Function() edit;
   final Color color;
 
   Future<void> onVote({ required BuildContext context, required bool up }) async {
-    String voteResult = await voteOnTest(test: testModel, up: up);
+    SaveTestResult voteResult = await voteOnTest(test: testModel, up: up);
 
-    if (voteResult != 'Ok' && context.mounted) {
+    asyncSetTestModel(voteResult.updatedTest);
+
+    if (voteResult.status != 'Ok' && context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text("You're not logged in! Log in to ${up ? 'up' : 'down'}vote.")),
+        SnackBar(content: Text(voteResult.status)),
       );
     }
   }
@@ -57,16 +63,7 @@ class TestCard extends StatelessWidget {
 
     List<Widget> options = [
       ElevatedButton(
-        onPressed: () {
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (BuildContext context) => PlayTestSolo(
-                testModel: testModel,
-              ),
-            ),
-          );
-        },
+        onPressed: playSolo,
         child: const Text('Play solo'),
       ),
     ];
@@ -89,16 +86,7 @@ class TestCard extends StatelessWidget {
     if (userOwnsTest) {
       options.add(
         ElevatedButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (BuildContext context) => MakeTest(
-                  testModel: testModel,
-                ),
-              ),
-            );
-          },
+          onPressed: edit,
           child: const Text('Edit'),
         ),
       );


### PR DESCRIPTION
So that screens can communicate model changes through `Navigator` without worrying about shared mutable state. Also, there's now a 'You have unsaved changes!' popup!